### PR TITLE
Update helper.js for Cordova 9 

### DIFF
--- a/scripts/ios/helper.js
+++ b/scripts/ios/helper.js
@@ -30,7 +30,7 @@ module.exports = {
      * (dSYMs) so that Crashlytics can display stack trace information in it's web console.
      */
     addShellScriptBuildPhase: function (context, xcodeProjectPath) {
-      var xcode = context.requireCordovaModule("xcode");
+      var xcode = require("xcode");
       // Read and parse the XCode project (.pxbproj) from disk.
       // File format information: http://www.monobjc.net/xcode-project-file-format.html
       var xcodeProject = xcode.project(xcodeProjectPath);
@@ -84,7 +84,7 @@ module.exports = {
      */
   removeShellScriptBuildPhase: function (context, xcodeProjectPath) {
 
-    var xcode = context.requireCordovaModule("xcode");
+    var xcode = require("xcode");
 
     // Read and parse the XCode project (.pxbproj) from disk.
     // File format information: http://www.monobjc.net/xcode-project-file-format.html


### PR DESCRIPTION
On Cordova CLI V9 and above, we get the following error on install : 

`Failed to install 'cordova-plugin-firebase': CordovaError: Using "requireCordovaModule" to load non-cordova module "xcode" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.`

Ref : https://stackoverflow.com/questions/56556954/failed-to-install-cordova-plugin-firebase-cordovaerror-using-requirecordova